### PR TITLE
refactor(lessons-learned): clarify canonical lesson workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shihyu's curated collection of agent skills.
 - **[agent-install-guide](skills/agent-install-guide/)** - Write installation guides that AI agents can reliably execute.
 - **[executing-plans-preflight](skills/executing-plans-preflight/)** - Run extensible preflight checks before superpowers:executing-plans, with branch safety as the default gate.
 - **[fanfuaji](skills/fanfuaji/)** - Chinese terminology conversion (Traditional ↔ Simplified) using [Fanhuaji](https://zhconvert.org/) API.
-- **[lessons-learned](skills/lessons-learned/)** - Capture reusable lessons after work and recall relevant lessons before execution with Zettelkasten cards.
+- **[lessons-learned](skills/lessons-learned/)** - Recall relevant lessons before non-trivial work and capture reusable lessons after meaningful corrections or outcomes.
 - **[skill-design](skills/skill-design/)** - Design or refactor agent skills with strict, portable and high-signal documentation structure.
 
 ## Installation
@@ -30,7 +30,7 @@ This repository includes reusable command templates in [`commands/`](commands/).
 
 - `lessons-learned-init`: Initialize lessons-learned setup for AGENTS.md or CLAUDE.md.
 - `lessons-learned-recall`: Recall relevant lessons before work with lessons-learned.
-- `lessons-learned-capture`: Capture reusable lessons at task end with lessons-learned.
+- `lessons-learned-capture`: Capture reusable lessons during corrections or at task end with lessons-learned.
 
 ## Naming Rule
 

--- a/commands/lessons-learned-capture.md
+++ b/commands/lessons-learned-capture.md
@@ -2,7 +2,7 @@
 description: "Capture reusable lessons"
 ---
 
-Invoke the `lessons-learned:lessons-learned` skill and follow the capture phase exactly as presented.
+Invoke the `lessons-learned:lessons-learned` skill and follow the **Capture Phase** in `SKILL.md`.
 
 Execute only the capture phase action for this invocation. Do not run other
 actions unless the user explicitly asks.

--- a/commands/lessons-learned-init.md
+++ b/commands/lessons-learned-init.md
@@ -24,7 +24,10 @@ Run setup for project instruction files.
 
 3. **Avoid duplication**
    - If multiple equivalent mandatory blocks exist, keep one canonical copy and
-     remove duplicates.
+      remove duplicates.
+
+Keep this command narrow: it only installs the canonical reminder block. Lesson
+memory behavior remains defined in `SKILL.md`.
 
 Execute only this flow for this invocation. Do not run other actions unless the
 user explicitly asks.

--- a/commands/lessons-learned-recall.md
+++ b/commands/lessons-learned-recall.md
@@ -2,7 +2,7 @@
 description: "Recall relevant lessons"
 ---
 
-Invoke the `lessons-learned:lessons-learned` skill and follow the recall phase exactly as presented.
+Invoke the `lessons-learned:lessons-learned` skill and follow the **Recall Phase** in `SKILL.md`.
 
 Execute only the recall phase action for this invocation. Do not run other
 actions unless the user explicitly asks.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,0 +1,38 @@
+{
+  "skill_name": "lessons-learned",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm about to refactor a non-trivial auth flow. Before I touch the code, load any relevant lessons and tell me what constraints I should keep in mind.",
+      "expected_output": "Uses the recall phase before implementation, determines scope, consults the lessons index if present, and reports loaded lesson constraints or a no-match outcome without inventing cards.",
+      "files": [],
+      "expectations": [
+        "Determines whether lesson storage or index exists before attempting recall",
+        "Uses scope and ranked recall logic or explicitly reports that no lessons match",
+        "Does not invent lesson cards or claim nonexistent constraints"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Correction: the migration baseline must run before applying tenant migrations. Capture that so we don't repeat it.",
+      "expected_output": "Uses the capture phase, treats the correction as reusable, updates or creates the appropriate lesson card and index entry, and reports the capture compactly.",
+      "files": [],
+      "expectations": [
+        "Treats the user correction as a capture trigger",
+        "Applies create-vs-update logic instead of blindly creating duplicates",
+        "Reports the capture result in a compact created or updated summary"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I just finished a bug fix. The fix only worked because timeout had to be set before client initialization. Capture it if that should become a reusable lesson.",
+      "expected_output": "Evaluates capture criteria, captures only if non-obvious and reusable, keeps the workflow aligned with the documented card template and validation rules, and reports what happened.",
+      "files": [],
+      "expectations": [
+        "Evaluates whether the lesson is non-obvious and reusable before capturing",
+        "Keeps the lesson card behavior aligned with the documented schema and validation rules",
+        "Explains whether it captured, updated, or skipped the lesson and why"
+      ]
+    }
+  ]
+}

--- a/skills/lessons-learned/README.md
+++ b/skills/lessons-learned/README.md
@@ -2,7 +2,7 @@
 
 Turn every costly mistake into reusable memory.
 
-`lessons-learned` gives your agent a lightweight self-improvement loop:
+`lessons-learned` gives an agent a lightweight self-improvement loop:
 
 - Recall relevant lessons before starting work
 - Capture reusable lessons after meaningful corrections or outcomes
@@ -14,71 +14,51 @@ Without a lesson loop, agents often repeat setup errors, forget preconditions, a
 
 This skill stores those insights as atomic Zettelkasten cards so future tasks can load only what matters.
 
-## What It Does
+## What It Maintains
 
 - Maintains `docs/lessons/_index.md` for fast ranking by tag/scope/confidence/date
 - Stores one lesson per card under `docs/lessons/<card-id>.md`
-- Captures only non-obvious, reusable lessons
-- Auto-captures qualifying lessons at task end
-- Assigns `confidence` by source and uses it in recall priority
-- Adds selective `related` links for high-value knowledge connections
-
-## What Counts as Non-Obvious
-
-- Hidden relationships between files/modules
-- Misleading errors that required a specific workaround
-- Non-obvious ordering, config, env var, or flag constraints
-- Files that must change together to keep behavior correct
+- Uses `confidence` and scope metadata to prioritize recall
+- Keeps `related` links selective so recall stays small and relevant
 
 ## When It Triggers
 
-### Task Start (Recall)
+- **Task start** - load relevant lessons before non-trivial implementation.
+- **User correction** - capture a reusable correction while the context is fresh.
+- **Task end** - evaluate whether a new lesson should be stored.
 
-Use when a new task begins and you want to preload relevant constraints.
+Typical prompts:
 
-Example prompts:
-
-- "Start implementing retry logic for webhook timeout handling."
 - "Before I touch migrations, load relevant lessons."
-
-### User Correction (Capture)
-
-Use when the user corrects approach and the correction is reusable.
-
-Example prompt:
-
-- "Correction: baseline must run before migrate."
-
-### Task End (Capture Evaluation)
-
-Use when finishing a task and a reusable rule emerged.
-
-Example prompt:
-
+- "Correction: baseline must run before migrate. Capture that."
 - "Done. The fix only worked after setting timeout before client initialization."
 
-## Recall and Capture Lifecycle
+## High-Level Lifecycle
 
 1. **Recall**
-   - Determine task scope (`project` / `module` / `feature`)
-   - Match task keywords to tags in `_index.md`
-   - Rank by `tag -> scope -> confidence(desc) -> date(desc)`
-   - For legacy cards without `confidence`, derive from `source`
-     (`user-correction=0.7`, `bug-fix=0.5`, `retrospective=0.3`, fallback `0.3`)
-   - Load 1-3 primary cards
-   - Optionally expand with up to 2 `related` cards
-   - Apply those lessons as constraints
+   - Read the lesson index if it exists.
+   - Rank cards by tags, scope, confidence, and recency.
+   - Load only the most relevant cards.
 
 2. **Capture**
-   - Evaluate whether the outcome is reusable and non-obvious
-   - Auto-capture if criteria are met
-   - Update or create card + index row
-   - Report `created/updated/skipped` in a compact capture report
+   - Store only non-obvious, reusable lessons.
+   - Update an existing card when the lesson already exists.
+   - Keep the index synchronized with card metadata.
 
-3. **Selective Linking**
-   - Add `related` links only when high-value gate is met
-   - Avoid speculative links
-   - Cap at 2 related links per card
+3. **Reuse**
+   - Apply loaded lessons as constraints on the current task.
+   - Report concise capture results when new memory is written.
+
+Detailed execution rules live in `SKILL.md`.
+
+## What Counts as Worth Capturing
+
+- Hidden relationships between files or modules
+- Misleading errors that required a specific workaround
+- Non-obvious ordering, config, env var, or flag constraints
+- Pairs or sets of files that must change together
+
+Avoid capturing obvious framework behavior, one-off facts, or session-only noise.
 
 ## File Layout
 
@@ -96,3 +76,4 @@ docs/lessons/
 - Do not capture one-off, non-reproducible facts.
 - Do not capture session-only noise (temporary paths/logs/local artifacts).
 - Do not create duplicate cards when an existing card can be updated.
+- Do not treat this README as the canonical spec; use `SKILL.md` for that.

--- a/skills/lessons-learned/SKILL.md
+++ b/skills/lessons-learned/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lessons-learned
-description: Use when starting, executing, or finishing non-trivial implementation tasks to recall relevant lessons before work and capture reusable corrections, mistakes, and decision rules after work.
+description: Use when starting, executing, or finishing non-trivial implementation tasks where reusable constraints may matter. Recall relevant lessons before work, capture reusable corrections or discoveries during and after work, and keep project memory in `docs/lessons/`.
 license: MIT
 metadata:
   author: shihyuho
@@ -9,9 +9,12 @@ metadata:
 
 # Lessons Learned
 
-A self-improvement loop that stores atomic Zettelkasten lesson cards, recalls
-relevant lessons before work, and captures reusable lessons after work to avoid
-repeating the same mistakes.
+Use this skill to maintain a lightweight project memory loop.
+
+Treat this file as the **single source of truth** for lesson-memory behavior:
+trigger rules, recall flow, capture flow, limits, and validation.
+`README.md`, `references/`, and phase-entry commands must not override those
+rules.
 
 ## Trigger Contract
 
@@ -38,9 +41,9 @@ When this skill is the primary process skill in a session:
 
 ## Storage
 
-All lessons live under **`docs/lessons/`** at the project root:
+Store all lesson artifacts under `docs/lessons/` at the project root:
 
-```
+```text
 docs/lessons/
 ├── _index.md
 ├── api-timeout-retry-pattern.md
@@ -48,13 +51,30 @@ docs/lessons/
 └── null-check-before-save.md
 ```
 
-## Recall Phase — Before Starting Work
+Each lesson card is one atomic Zettelkasten note. Keep one reusable lesson per
+card.
+
+## Canonical Limits
+
+Apply these limits everywhere in the skill package:
+
+- Load **1-3** primary cards during recall.
+- Load up to **2** related cards.
+- Load at most **5** cards total.
+- Use **0-2** `related` links per card.
+- Use **3-6** tags per card.
+- Keep `confidence` in the inclusive range `0.0-0.9`.
+
+If another file conflicts with these limits, this file wins.
+
+## Recall Phase
 
 Run this phase before writing code.
 
 1. Extract task keywords (technology, failure mode, domain terms).
-2. Apply index recovery rule:
-   - If `docs/lessons/_index.md` is missing, skip recall on first run (no cards) or rebuild `_index.md` from existing card frontmatter before recall.
+2. Determine whether lesson storage exists:
+   - If `docs/lessons/` does not exist, treat this as first-run state and skip recall.
+   - If `docs/lessons/` exists but `_index.md` does not, rebuild `_index.md` from existing card frontmatter before recall.
 3. Determine working scope from the task context:
    - `project` for cross-cutting or repo-wide concerns
    - `module` for package/directory-level concerns
@@ -63,18 +83,30 @@ Run this phase before writing code.
 5. Rank candidates with this order:
    `tag match -> scope match -> confidence (desc) -> date (desc)`.
    - Legacy fallback: if a card has no `confidence`, derive it from `source`
-     (`user-correction=0.7`, `bug-fix=0.5`, `retrospective=0.3`). If both
-     are missing, use `0.3`.
+      (`user-correction=0.7`, `bug-fix=0.5`, `retrospective=0.3`). If both
+      are missing, use `0.3`.
 6. Load **1-3** primary cards.
-7. Expand with `related` links from primary cards, load up to **2** additional cards.
-8. Enforce hard cap: primary + related cards must not exceed **5** total.
+7. Expand with `related` links from primary cards, loading up to **2**
+   additional cards.
+8. Enforce the hard cap: primary plus related cards must not exceed **5**
+   total.
 9. Apply loaded lessons as constraints for current work and mention loaded card IDs briefly.
 
 If no cards match, continue work without lesson constraints.
 
-## Capture Phase — After Completing Work
+### Recall Warnings
+
+Treat these as non-blocking and continue:
+
+- `docs/lessons/` is missing on first run.
+- `_index.md` had to be rebuilt.
+- A loaded card is missing `confidence` and needs legacy fallback.
+- A `related` target is missing.
+
+## Capture Phase
 
 Run this phase when any of these conditions are met:
+
 - The user corrected your approach
 - The user asks for capture
 - A bug fix revealed a reusable pattern
@@ -110,6 +142,15 @@ Skip if:
 
 Generate a semantic kebab-case ID that describes the lesson (e.g., `api-timeout-retry-pattern`).
 
+Before writing a new card, check for a semantically similar existing card and
+make the decision explicit:
+
+- `decision=create` when no similar card exists.
+- `decision=update` when a similar card already covers the same lesson.
+
+Surface this decision in the capture output. Do not jump straight to card
+content without stating whether you are creating or updating.
+
 Assign a `scope` before writing the card:
 - `project` for repo-wide constraints
 - `module` for package/directory-level constraints
@@ -124,12 +165,16 @@ If the user confirms a lesson was useful, increase `confidence` by `+0.1`
 (max `0.9`).
 
 Write the card to `docs/lessons/<id>.md` using the template in
-[references/card-template.md](references/card-template.md).
+`references/card-template.md`.
 
 Before creating a new card, check semantic duplication:
 
 - If an existing card is semantically similar, update that card instead of creating a duplicate.
 - Preserve existing card ID when updating.
+
+Minimal correction-capture example:
+
+> Lessons capture report: decision=update, updated=1 (`db-migration-run-order`), skipped=0
 
 Card fields:
 
@@ -152,6 +197,8 @@ Task-end behavior:
 
 - If capture criteria are met, auto-capture without asking for permission first.
 - After capture, report what was created or updated.
+- For normal user-facing output, prefer a short capture summary.
+- Do not reproduce the full card body unless the user asks to inspect it.
 
 ### Step 3 — Update the index
 
@@ -173,7 +220,15 @@ Then keep rows sorted by `Date` descending (newest first).
 ### Step 4 — Confirm with user
 
 Tell the user what was captured using a compact report, e.g.:
-> ✏️ Lessons capture report: created=1 (`api-timeout-retry-pattern`), updated=1 (`db-migration-run-order`), skipped=1 (obvious behavior)
+
+> Lessons capture report: created=1 (`api-timeout-retry-pattern`), updated=1 (`db-migration-run-order`), skipped=1 (obvious behavior)
+
+If capture occurred, include the create-vs-update decision in the report when it
+helps explain the outcome, for example `decision=create` or `decision=update`.
+
+Keep this confirmation short. Prefer the decision, the affected card ID, and a
+one-line rule summary. Avoid dumping the full markdown card or index contents in
+normal output.
 
 ## Linking Rule
 
@@ -192,10 +247,9 @@ Linking constraints:
 - Use deterministic ranking from `references/linking-heuristics.md`.
 - Do not add weak or speculative links.
 
-Broken related targets:
+Broken related targets are non-blocking:
 
 - If a related target is missing, ignore it and warn.
-- Treat this as non-blocking.
 - Continue recall/capture flow.
 
 ## Anti-patterns
@@ -208,7 +262,8 @@ Broken related targets:
 
 ## Validation
 
-Apply these checks during capture or update:
+Apply these checks during capture or update. These are blocking failures unless
+explicitly listed as warnings elsewhere.
 
 - Card filename equals `id` slug.
 - `date` format is ISO `YYYY-MM-DD`.
@@ -223,9 +278,12 @@ Apply these checks during capture or update:
 
 ## Integration Guide
 
-When used with other skills in the same session, follow the Trigger Contract
-above as the single source of truth (task start recall, correction capture,
-task-end capture evaluation).
+When used with other skills in the same session, follow the Trigger Contract as
+the single source of truth:
+
+- task start -> recall
+- user correction during work -> capture
+- task end -> capture evaluation
 
 This is a **non-replaceable** step — lesson capture cannot be substituted by
 todo trackers, progress files, or other skill artifacts.

--- a/skills/lessons-learned/references/card-template.md
+++ b/skills/lessons-learned/references/card-template.md
@@ -2,6 +2,9 @@
 
 Use this template when creating a new lesson card.
 
+This file supports `SKILL.md`. If this file and `SKILL.md` disagree, follow
+`SKILL.md`.
+
 ```markdown
 ---
 id: <semantic-kebab-case-id>
@@ -50,3 +53,4 @@ related: ["[[related-card-id-1]]"]
 - `confidence` is numeric and between 0.0 and 0.9.
 - `related` count is between 0 and 2.
 - Every `related` target resolves to an existing card ID.
+- Index metadata should match the card after any update.

--- a/skills/lessons-learned/references/linking-heuristics.md
+++ b/skills/lessons-learned/references/linking-heuristics.md
@@ -2,6 +2,8 @@
 
 Use these rules to build `related` links for lesson cards.
 
+This file supports `SKILL.md`. It does not define independent limits.
+
 ## High-Value Gate (2-of-4)
 
 Only create `related` links when at least **2** of these conditions are true:
@@ -22,7 +24,7 @@ When multiple candidates are available, rank in this order:
 3. Card recency by `date` (newer first)
 4. Stable tie-breaker by `id` (ascending)
 
-Select the top candidates and cap at 3 links.
+Select the top candidates and cap at 2 links.
 
 ## Link Constraints
 


### PR DESCRIPTION
## Summary
- centralize `lessons-learned` recall and capture rules in `SKILL.md` so commands, references, and README stay aligned
- clarify first-run recall behavior, validation boundaries, and create-vs-update capture decisions for lesson cards
- add focused eval prompts for recall, correction capture, and task-end capture scenarios

## Test Plan
- [x] `npx --yes skills-ref validate ./skills/lessons-learned`